### PR TITLE
Fixed dpad and car velocity errors in 'camera example'

### DIFF
--- a/examples/camera-example/player.script
+++ b/examples/camera-example/player.script
@@ -25,9 +25,9 @@ end
 
 function update(self, dt)
     -- Calculate new velocity based on current acceleration
-    if vmath.length(self.velocity) < max_velocity then
-	    self.velocity = self.velocity + self.acceleration * dt
-	end
+	-- Only Y component of the vectors is used
+	local new_velocity = self.velocity.y + self.acceleration.y * dt
+	self.velocity.y = math.max(-max_velocity, math.min(new_velocity, max_velocity))
 	
     -- Calculate the new positions of front and back wheels
     local front_vel = vmath.rotate(self.steer_angle, self.velocity)

--- a/examples/main/controls.gui_script
+++ b/examples/main/controls.gui_script
@@ -51,11 +51,13 @@ function on_message(self, message_id, message, sender)
 			end 
 			-- We got to sort out the dpad click positions by ourselves because of the button shapes.
 			local button = dpad_which_button(message.x, message.y)
-			if button and message.action.pressed then
-				msg.post("/sound#click", "play_sound")
-			end
-			if self.controls_receiver then
-				msg.post(self.controls_receiver, button)
+			if button then
+				if message.action.pressed then
+					msg.post("/sound#click", "play_sound")
+				end
+				if self.controls_receiver then
+					msg.post(self.controls_receiver, button)
+				end
 			end
 		elseif message.button == "a" or message.button == "b" then
 			if not self.controls_active then


### PR DESCRIPTION
Dpad control was trying to do msg.post() call even when it was clicked in the corners, resulting in error (button == false).
Car velocity was getting stuck after exceeding 'max_velocity' value.